### PR TITLE
Changed request code for permission in Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.5
+
+* Fix for colliding permission request with image_picker plugin
+
 ## 0.0.4
 
 * Return type changed to bool(true for success and false for everything else)

--- a/android/src/main/kotlin/carnegietechnologies/gallery_saver/GallerySaver.kt
+++ b/android/src/main/kotlin/carnegietechnologies/gallery_saver/GallerySaver.kt
@@ -139,7 +139,7 @@ class GallerySaver internal constructor(private val activity: Activity) : Plugin
 
     companion object {
 
-        private const val REQUEST_EXTERNAL_IMAGE_STORAGE_PERMISSION = 2345
+        private const val REQUEST_EXTERNAL_IMAGE_STORAGE_PERMISSION = 2408
 
         private const val KEY_PATH = "path"
     }

--- a/gallery_saver.iml
+++ b/gallery_saver.iml
@@ -17,7 +17,6 @@
       <excludeFolder url="file://$MODULE_DIR$/example/ios/.symlinks/plugins/gallery_saver/example/.dart_tool" />
       <excludeFolder url="file://$MODULE_DIR$/example/ios/.symlinks/plugins/gallery_saver/example/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/example/ios/.symlinks/plugins/gallery_saver/example/build" />
-      <excludeFolder url="file://$MODULE_DIR$/example/ios/.symlinks/plugins/gallery_saver/example/ios/Flutter/App.framework/flutter_assets/packages" />
       <excludeFolder url="file://$MODULE_DIR$/example/ios/Flutter/App.framework/flutter_assets/packages" />
     </content>
     <orderEntry type="sourceFolder" forTests="false" />

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: gallery_saver
 description: Saves images and videos to gallery and photos. Temporary file from camera gets saved to external storage by passing its path to the methods saveImage and saveVideo.
-version: 0.0.4
+version: 0.0.5
 author: Carnegie Technologies d.o.o <devoffice@carnegietechnologies.com>
 homepage: https://github.com/CarnegieTechnologies/gallery_saver
 


### PR DESCRIPTION
gallery_saver was using the same request code for storage permission as image_picker for camera,
and it was crashing android app.

CWF-353