### PR TITLE
Save large video - fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.2
+
+* Saving large video files - fix
+
 ## 1.0.1
 
 * Changed description

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: gallery_saver
 description: Saves images and videos from network or temporary file to external storage. Both images and videos will be visible in Android Gallery and iOS Photos.
-version: 1.0.1
+version: 1.0.2
 author: Carnegie Technologies d.o.o <devoffice@carnegietechnologies.com>
 homepage: https://github.com/CarnegieTechnologies/gallery_saver
 


### PR DESCRIPTION
There is a fix for saving large videos.
Now we allocate a buffer with the size of 8 mb that we use for reading and writing files.
Also, now we are deleting video file from cache after save is completed.


CWF-377
CWF-360