### PR TITLE
Fixed issue with improper mime types causing crash

### DIFF
--- a/android/src/main/kotlin/carnegietechnologies/gallery_saver/FileUtils.kt
+++ b/android/src/main/kotlin/carnegietechnologies/gallery_saver/FileUtils.kt
@@ -36,7 +36,8 @@ internal object FileUtils {
     fun insertImage(contentResolver: ContentResolver, path: String): Boolean {
 
         val file = File(path)
-        val mimeType = MimeTypeMap.getFileExtensionFromUrl(file.toString())
+        val extension = MimeTypeMap.getFileExtensionFromUrl(file.toString())
+        var mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension)
         var source = getBytesFromFile(file)
 
         val rotatedBytes = getRotatedBytesIfNecessary(source, path)


### PR DESCRIPTION
Currently, the image type is being stored as simply the file extension. This worked for me on android 9, however, attempting to use it on a device running android 10 resulted in a runtime exception where gallery_saver's android component would crash the app, because it attempted to store an image with an improper MIME type.

My use case was storing a png file - the image was being stored with the "png" mime type, which it didn't like. It was crashing unless the type was "image/png." Doing a bit of digging found this issue in the source - the MIME_TYPE value was really just the file extension, not the MIME type decoded from the MimeTypeMap. 

This change has been tested on Android 9 and 10, compiling and running properly on both.