### PR TITLE
Fixed issue with improper mime types for video.

### DIFF
--- a/android/src/main/kotlin/carnegietechnologies/gallery_saver/FileUtils.kt
+++ b/android/src/main/kotlin/carnegietechnologies/gallery_saver/FileUtils.kt
@@ -236,7 +236,8 @@ internal object FileUtils {
         val inputStream: InputStream?
         val outputStream: OutputStream?
 
-        val mimeType = MimeTypeMap.getFileExtensionFromUrl(inputFile.toString())
+        val extension = MimeTypeMap.getFileExtensionFromUrl(inputFile.toString())
+        val mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension)
 
         val albumDir = File(getAlbumFolderPath(folderName, MediaType.video))
         val videoFilePath = File(albumDir, inputFile.name).absolutePath


### PR DESCRIPTION
I encountered an issue with saving videos on Android. Upon inspecting the code I can see that gallery_saver uses the file extension instead of the mime type for videos, which causes a problem further down in the Android classes.

I can see that this same issue has been fixed for images, but not yet for video.

I have tested the fix on my Pixel 2 XL.