### PR TITLE
fix error if image was selected twice

### DIFF
--- a/android/src/main/kotlin/carnegietechnologies/gallery_saver/FileUtils.kt
+++ b/android/src/main/kotlin/carnegietechnologies/gallery_saver/FileUtils.kt
@@ -76,11 +76,13 @@ internal object FileUtils {
                     outputStream.write(source)
                 }
 
-                val pathId = ContentUris.parseId(imageUri)
-                val miniThumb = MediaStore.Images.Thumbnails.getThumbnail(
-                    contentResolver, pathId, MediaStore.Images.Thumbnails.MINI_KIND, null
-                )
-                storeThumbnail(contentResolver, miniThumb, pathId)
+                if (imageUri != null) {
+                    val pathId = ContentUris.parseId(imageUri)
+                    val miniThumb = MediaStore.Images.Thumbnails.getThumbnail(
+                            contentResolver, pathId, MediaStore.Images.Thumbnails.MINI_KIND, null
+                    )
+                    storeThumbnail(contentResolver, miniThumb, pathId)
+                }
             } else {
                 if (imageUri != null) {
                     contentResolver.delete(imageUri, null, null)


### PR DESCRIPTION
added null check for imageUri to solve : https://github.com/CarnegieTechnologies/gallery_saver/issues/37 & https://github.com/CarnegieTechnologies/gallery_saver/issues/31