### PR TITLE
Moves the image validation to native

### DIFF
--- a/android/src/main/kotlin/carnegietechnologies/gallery_saver/GallerySaver.kt
+++ b/android/src/main/kotlin/carnegietechnologies/gallery_saver/GallerySaver.kt
@@ -3,6 +3,7 @@ package carnegietechnologies.gallery_saver
 import android.Manifest
 import android.app.Activity
 import android.content.pm.PackageManager
+import android.graphics.BitmapFactory
 import androidx.core.app.ActivityCompat
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
@@ -23,6 +24,18 @@ class GallerySaver internal constructor(private val activity: Activity) :
 
     private val job = Job()
     private val uiScope = CoroutineScope(Dispatchers.Main + job)
+
+    /**
+     * Checks if the file specified by the [path] is an image.
+     *
+     * The function returns true/false depending on whether the bounds can be read.
+     */
+    internal fun isImage(path: String): Boolean {
+        val options = BitmapFactory.Options()
+        options.inJustDecodeBounds = true
+        BitmapFactory.decodeFile(path, options)
+        return (options.outWidth != -1 && options.outHeight != -1)
+    }
 
     /**
      * Saves image or video to device

--- a/android/src/main/kotlin/carnegietechnologies/gallery_saver/GallerySaverPlugin.kt
+++ b/android/src/main/kotlin/carnegietechnologies/gallery_saver/GallerySaverPlugin.kt
@@ -26,6 +26,12 @@ class GallerySaverPlugin private constructor(
         when (call.method) {
             "saveImage" -> gallerySaver.checkPermissionAndSaveFile(call, result, MediaType.image)
             "saveVideo" -> gallerySaver.checkPermissionAndSaveFile(call, result, MediaType.video)
+            "image.check" -> {
+                val path = call.arguments<String>()
+                val isImage = gallerySaver.isImage(path)
+
+                result.success(isImage)
+            }
             else -> result.notImplemented()
         }
     }

--- a/lib/files.dart
+++ b/lib/files.dart
@@ -9,15 +9,7 @@ const List<String> videoFormats = [
   '.mkv',
   '.flv'
 ];
-const List<String> imageFormats = [
-  '.jpeg',
-  '.png',
-  '.jpg',
-  '.gif',
-  '.webp',
-  '.tif',
-  '.heic'
-];
+
 const http = 'http';
 
 bool isLocalFilePath(String path) {
@@ -27,6 +19,3 @@ bool isLocalFilePath(String path) {
 
 bool isVideo(String path) =>
     videoFormats.contains(extension(path).toLowerCase());
-
-bool isImage(String path) =>
-    imageFormats.contains(extension(path).toLowerCase());

--- a/lib/gallery_saver.dart
+++ b/lib/gallery_saver.dart
@@ -46,7 +46,7 @@ class GallerySaver {
     if (path == null || path.isEmpty) {
       throw ArgumentError(pleaseProvidePath);
     }
-    if (!isImage(path)) {
+    if (!await _checkIfFileIsImage(path)) {
       throw ArgumentError(fileIsNotImage);
     }
     if (!isLocalFilePath(path)) {
@@ -63,6 +63,10 @@ class GallerySaver {
     }
 
     return result;
+  }
+
+  static Future<bool> _checkIfFileIsImage(String path) async {
+    return _channel.invokeMethod<bool>('image.check', path);
   }
 
   static Future<File> _downloadFile(String url) async {


### PR DESCRIPTION
The image validation should really be done on the native side, so that users can be sure the image is supported by the active device.

A typical use case is when developers try to share cache files (which may not have file extensions).