### PR TITLE
Add a workaround of the crash for Android

### DIFF
--- a/android/src/main/kotlin/carnegietechnologies/gallery_saver/FileUtils.kt
+++ b/android/src/main/kotlin/carnegietechnologies/gallery_saver/FileUtils.kt
@@ -92,6 +92,8 @@ internal object FileUtils {
         } catch (e: IOException) {
             contentResolver.delete(imageUri!!, null, null)
             return false
+        } catch (t: Throwable) { // IllegalArgumentException: Invalid column NULL
+            return false
         }
 
         return true


### PR DESCRIPTION
My app was crashed on saving images (Pixel 3a).
So I added this workaround.

related issue: https://github.com/CarnegieTechnologies/gallery_saver/issues/58