### PR TITLE
fix url with query string problem

### DIFF
--- a/lib/files.dart
+++ b/lib/files.dart
@@ -25,8 +25,18 @@ bool isLocalFilePath(String path) {
   return !uri.scheme.contains(http);
 }
 
-bool isVideo(String path) =>
-    videoFormats.contains(extension(path).toLowerCase());
+bool isVideo(String path) {
+  bool output = false;
+  videoFormats.forEach((videoFormat) {
+    if (path.toLowerCase().contains(videoFormat)) output = true;
+  });
+  return output;
+}
 
-bool isImage(String path) =>
-    imageFormats.contains(extension(path).toLowerCase());
+bool isImage(String path) {
+  bool output = false;
+  imageFormats.forEach((imageFormat) {
+    if (path.toLowerCase().contains(imageFormat)) output = true;
+  });
+  return output;
+}

--- a/lib/gallery_saver.dart
+++ b/lib/gallery_saver.dart
@@ -68,10 +68,12 @@ class GallerySaver {
   static Future<File> _downloadFile(String url) async {
     print(url);
     http.Client _client = new http.Client();
-    var req = await _client.get(Uri.parse(url));
+    var fileUri = Uri.parse(url);
+    var req = await _client.get(fileUri);
+    var fileName = fileUri.pathSegments.last;
     var bytes = req.bodyBytes;
     String dir = (await getTemporaryDirectory()).path;
-    File file = new File('$dir/${basename(url)}');
+    File file = new File('$dir/$fileName');
     await file.writeAsBytes(bytes);
     print('File size:${await file.length()}');
     print(file.path);


### PR DESCRIPTION
when image url with query string like 'https://firebasestorage.googleapis.com/v0/b/eventat-4ba96.appspot.com/o/2019-Metrology-Events.jpg?alt=media&token=bfc47032-5173-4b3f-86bb-9659f46b362a' can not pass the isImage check and download.