### PR TITLE
Adding optionnal headers to saveImage and saveVideo

### DIFF
--- a/lib/gallery_saver.dart
+++ b/lib/gallery_saver.dart
@@ -18,7 +18,7 @@ class GallerySaver {
   static const MethodChannel _channel = const MethodChannel(channelName);
 
   ///saves video from provided temp path and optional album name in gallery
-  static Future<bool> saveVideo(String path, {String albumName}) async {
+  static Future<bool> saveVideo(String path, {String albumName, Map<String, String> headers}) async {
     File tempFile;
     if (path == null || path.isEmpty) {
       throw ArgumentError(pleaseProvidePath);
@@ -27,7 +27,7 @@ class GallerySaver {
       throw ArgumentError(fileIsNotVideo);
     }
     if (!isLocalFilePath(path)) {
-      tempFile = await _downloadFile(path);
+      tempFile = await _downloadFile(path, headers: headers);
       path = tempFile.path;
     }
     bool result = await _channel.invokeMethod(
@@ -41,7 +41,7 @@ class GallerySaver {
   }
 
   ///saves image from provided temp path and optional album name in gallery
-  static Future<bool> saveImage(String path, {String albumName}) async {
+  static Future<bool> saveImage(String path, {String albumName, Map<String, String> headers}) async {
     File tempFile;
     if (path == null || path.isEmpty) {
       throw ArgumentError(pleaseProvidePath);
@@ -50,7 +50,7 @@ class GallerySaver {
       throw ArgumentError(fileIsNotImage);
     }
     if (!isLocalFilePath(path)) {
-      tempFile = await _downloadFile(path);
+      tempFile = await _downloadFile(path, headers: headers);
       path = tempFile.path;
     }
 
@@ -65,10 +65,10 @@ class GallerySaver {
     return result;
   }
 
-  static Future<File> _downloadFile(String url) async {
+  static Future<File> _downloadFile(String url, {Map<String, String> headers}) async {
     print(url);
     http.Client _client = new http.Client();
-    var req = await _client.get(Uri.parse(url));
+    var req = await _client.get(Uri.parse(url), headers: headers);
     var bytes = req.bodyBytes;
     String dir = (await getTemporaryDirectory()).path;
     File file = new File('$dir/${basename(url)}');

--- a/lib/gallery_saver.dart
+++ b/lib/gallery_saver.dart
@@ -68,7 +68,7 @@ class GallerySaver {
   static Future<File> _downloadFile(String url, {Map<String, String> headers}) async {
     print(url);
     http.Client _client = new http.Client();
-    var req = await _client.get(Uri.parse(url), headers: headers);
+    var req = headers != null ? await _client.get(Uri.parse(url), headers: headers) : await _client.get(Uri.parse(url));
     var bytes = req.bodyBytes;
     String dir = (await getTemporaryDirectory()).path;
     File file = new File('$dir/${basename(url)}');


### PR DESCRIPTION
I recently opened an issue (78), about adding optionnal headers to the saveImage / saveVideo methods, because sometimes you want to download images or ressources that are protected, by a bearer token for example. I simply added optionnal parameter to the saveImage and saveVideo methods which is an header parameter. 
If a header parameter is here, it will be used by the get method. 

Hope it will helps :)