### PR TITLE
Fixed: Crashes when create app in background or Isolate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.3+1
+
+* Fixed: Exception while register in background mode.
+
 ## 2.0.3
 
 * Android - Invalid column 

--- a/android/src/main/kotlin/carnegietechnologies/gallery_saver/GallerySaverPlugin.kt
+++ b/android/src/main/kotlin/carnegietechnologies/gallery_saver/GallerySaverPlugin.kt
@@ -12,6 +12,14 @@ class GallerySaverPlugin private constructor(
     companion object {
         @JvmStatic
         fun registerWith(registrar: Registrar) {
+            if (registrar.activity() == null) {
+                // If a background flutter view tries to register the plugin,
+                // there will be no activity from the registrar,
+                // we stop the registering process immediately
+                // because the GallerySaver requires an activity.
+                return
+            }
+
             val channel = MethodChannel(registrar.messenger(),
                     "gallery_saver")
             val gallerySaver = GallerySaver(registrar.activity())

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -73,7 +73,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.1"
+    version: "2.0.3+1"
   http:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: gallery_saver
 description: Saves images and videos from network or temporary file to external storage. Both images and videos will be visible in Android Gallery and iOS Photos.
-version: 2.0.3
+version: 2.0.3+1
 homepage: https://github.com/CarnegieTechnologies/gallery_saver
 
 environment:


### PR DESCRIPTION
### Problem

When we create `FlutterEngine` with our app in background (create Isolate, warmup another engine instance, etc), we doesn't have an  `Activity`. So when plugin's `registerWith() called - it throws an Exception. This is breaks registration of all following plugins and we can see message in console like this:

```
Tried to automatically register plugins with FlutterEngine (io.flutter.embedding.engine.FlutterEngine@7eaf22b) but could not find and invoke the GeneratedPluginRegistrant.
```

This leads to crashes in runtime, when we trying to use any of other plugins in this app instance.

**Related issues** #72, #64, #43 

### Solution 

Add check for `activity()` is null, to make plugin does not break other plugins when Flutter created in background or isolate.

This is how [image_picker](https://pub.dev/packages/image_picker) solve this issue.