### PR TITLE
Upgrade http dependency version

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   flutter:
     sdk: flutter
   path_provider: ^1.2.0
-  http: ^0.12.0+2
+  http: ^0.13.0
   path: ^1.6.2
 
 dev_dependencies:


### PR DESCRIPTION
# Issue
Incompatible combination of dependencies:
```yaml
image_picker: ^0.7.1
gallery_saver: ^2.0.3
```
Because gallery_saver >=1.0.0 depends on http ^0.12.0+2 and image_picker_platform_interface >=2.0.0 depends on http ^0.13.0, gallery_saver >=1.0.0 is incompatible with image_picker_platform_interface >=2.0.0.
And because image_picker >=0.7.0 depends on image_picker_platform_interface ^2.0.0, gallery_saver >=1.0.0 is incompatible with image_picker >=0.7.0.

# Proposed solution 
Upgrade the `http` dependency from `http: ^0.12.0+2` to `http: ^0.13.0`.
