### PR TITLE
Disregard query string when checking if path points to image/video

### DIFF
--- a/lib/files.dart
+++ b/lib/files.dart
@@ -26,7 +26,7 @@ bool isLocalFilePath(String path) {
 }
 
 bool isVideo(String path) =>
-    videoFormats.contains(extension(path).toLowerCase());
+    videoFormats.contains(fromUri(extension(path)).toLowerCase());
 
 bool isImage(String path) =>
-    imageFormats.contains(extension(path).toLowerCase());
+    imageFormats.contains(fromUri(extension(path)).toLowerCase());

--- a/test/gallery_saver_test.dart
+++ b/test/gallery_saver_test.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:gallery_saver/gallery_saver.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   const MethodChannel channel = MethodChannel('gallery_saver');
 
   setUp(() {

--- a/test/gallery_saver_test.dart
+++ b/test/gallery_saver_test.dart
@@ -3,6 +3,8 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:gallery_saver/gallery_saver.dart';
 
+import '../lib/files.dart';
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -30,5 +32,15 @@ void main() {
 
   test('save video', () async {
     expect(await GallerySaver.saveVideo('/storage/emulated/video.mov'), false);
+  });
+
+  test('disregard query string for image', () {
+    const String url = "https://placeholder.com/400x400.jpg?remove=true";
+    expect(isImage(url), true);
+  });
+
+  test('disregard query string for video', () {
+    const String url = "https://placeholder.com/400x400.mov?remove=true";
+    expect(isVideo(url), true);
   });
 }


### PR DESCRIPTION
Fixes #87 

This PR also fixes tests in general by including [`TestWidgetsFlutterBinding.ensureInitialized`](https://api.flutter.dev/flutter/flutter_test/TestWidgetsFlutterBinding/ensureInitialized.html).