### PR TITLE
Fix type mismatch error

### DIFF
--- a/android/src/main/kotlin/carnegietechnologies/gallery_saver/FileUtils.kt
+++ b/android/src/main/kotlin/carnegietechnologies/gallery_saver/FileUtils.kt
@@ -276,10 +276,10 @@ internal object FileUtils {
                 }
             }
         } catch (fnfE: FileNotFoundException) {
-            Log.e("GallerySaver", fnfE.message)
+            Log.e("GallerySaver", fnfE.message ?: fnfE.toString())
             return false
         } catch (e: Exception) {
-            Log.e("GallerySaver", e.message)
+            Log.e("GallerySaver", e.message ?: e.toString())
             return false
         }
         return true


### PR DESCRIPTION
Fixes the following build error:

```
e: /Users/misir/Workspace/tools/flutter/.pub-cache/hosted/pub.dartlang.org/gallery_saver-2.1.0/android/src/main/kotlin/carnegietechnologies/gallery_saver/FileUtils.kt: (279, 35): Type mismatch: inferred type is String? but String was expected
e: /Users/misir/Workspace/tools/flutter/.pub-cache/hosted/pub.dartlang.org/gallery_saver-2.1.0/android/src/main/kotlin/carnegietechnologies/gallery_saver/FileUtils.kt: (282, 35): Type mismatch: inferred type is String? but String was expected

FAILURE: Build failed with an exception.
```

Update:

Fixes #96