### PR TITLE
android: Fix a bug that the gallery saver hangs after it requests permission

### DIFF
--- a/android/src/main/kotlin/carnegietechnologies/gallery_saver/GallerySaver.kt
+++ b/android/src/main/kotlin/carnegietechnologies/gallery_saver/GallerySaver.kt
@@ -79,24 +79,25 @@ class GallerySaver internal constructor(private val activity: Activity) :
         pendingResult = null
     }
 
+    private fun finishWithFailure() {
+        pendingResult!!.success(false)
+        pendingResult = null
+    }
+
     override fun onRequestPermissionsResult(
         requestCode: Int, permissions: Array<String>, grantResults: IntArray
     ): Boolean {
-        val permissionGranted = grantResults.isNotEmpty()
-                && grantResults[0] == PackageManager.PERMISSION_GRANTED
-
         if (requestCode == REQUEST_EXTERNAL_IMAGE_STORAGE_PERMISSION) {
+            val permissionGranted = grantResults.isNotEmpty()
+                    && grantResults[0] == PackageManager.PERMISSION_GRANTED
             if (permissionGranted) {
-                if (mediaType == MediaType.video) {
-                    FileUtils.insertVideo(activity.contentResolver, filePath, albumName)
-                } else {
-                    FileUtils.insertImage(activity.contentResolver, filePath, albumName)
-                }
+                saveMediaFile()
+            } else {
+                finishWithFailure()
             }
-        } else {
-            return false
+            return true
         }
-        return true
+        return false
     }
 
     companion object {

--- a/android/src/main/kotlin/carnegietechnologies/gallery_saver/GallerySaverPlugin.kt
+++ b/android/src/main/kotlin/carnegietechnologies/gallery_saver/GallerySaverPlugin.kt
@@ -36,6 +36,7 @@ class GallerySaverPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     override fun onAttachedToActivity(binding: ActivityPluginBinding) {
         this.activity = binding.activity
         gallerySaver = GallerySaver(activity!!)
+        binding.addRequestPermissionsResultListener(gallerySaver!!)
     }
 
 


### PR DESCRIPTION
The problem is twofold. Firstly, the `gallerySaver` is never registered as a `RequestPermissionsResult` handler, so the function `onRequestPermissionsResult` will never be called after the user makes a decision. Secondly, in `onRequestPermissionsResult`, the `pendingResult` is never finished with a result. This PR fixes these bugs.