### PR TITLE
FIx saveVideo: albumName, Video duration, and android < 29 compatibility

### DIFF
--- a/android/src/main/kotlin/carnegietechnologies/gallery_saver/FileUtils.kt
+++ b/android/src/main/kotlin/carnegietechnologies/gallery_saver/FileUtils.kt
@@ -13,6 +13,7 @@ import android.util.Log
 import android.webkit.MimeTypeMap
 import androidx.exifinterface.media.ExifInterface
 import java.io.*
+import android.media.MediaMetadataRetriever
 
 /**
  * Core implementation of methods related to File manipulation
@@ -257,22 +258,23 @@ internal object FileUtils {
         val videoFilePath = File(albumDir, inputFile.name).absolutePath
 
         val values = ContentValues()
-        if (android.os.Build.VERSION.SDK_INT < 29) {
-            values.put(MediaStore.Video.VideoColumns.DATA, videoFilePath)
-        }
-
         values.put(MediaStore.Video.Media.TITLE, inputFile.name)
         values.put(MediaStore.Video.Media.DISPLAY_NAME, inputFile.name)
         values.put(MediaStore.Video.Media.MIME_TYPE, mimeType)
-        // Add the date meta data to ensure the image is added at the front of the gallery
         values.put(MediaStore.Video.Media.DATE_ADDED, System.currentTimeMillis())
         values.put(MediaStore.Video.Media.DATE_MODIFIED, System.currentTimeMillis())
+        values.put(MediaStore.Video.Media.DATE_TAKEN, System.currentTimeMillis())
 
-        if (android.os.Build.VERSION.SDK_INT >= 29) {
-            values.put(MediaStore.Video.Media.DATE_TAKEN, System.currentTimeMillis())
+        if (android.os.Build.VERSION.SDK_INT < 29) {
+            val r = MediaMetadataRetriever()
+            r.setDataSource(inputPath)
+            val durString = r.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)
+            val duration = durString!!.toInt()
+            
+            values.put(MediaStore.Video.Media.DURATION, duration)
+        } else {
             values.put(MediaStore.Video.Media.RELATIVE_PATH, Environment.DIRECTORY_MOVIES + File.separator + folderName)
         }
-
 
         try {
             val url = contentResolver.insert(MediaStore.Video.Media.EXTERNAL_CONTENT_URI, values)

--- a/android/src/main/kotlin/carnegietechnologies/gallery_saver/FileUtils.kt
+++ b/android/src/main/kotlin/carnegietechnologies/gallery_saver/FileUtils.kt
@@ -257,18 +257,20 @@ internal object FileUtils {
         val videoFilePath = File(albumDir, inputFile.name).absolutePath
 
         val values = ContentValues()
+        if (android.os.Build.VERSION.SDK_INT < 29) {
+            values.put(MediaStore.Video.VideoColumns.DATA, videoFilePath)
+        }
 
         values.put(MediaStore.Video.Media.TITLE, inputFile.name)
         values.put(MediaStore.Video.Media.DISPLAY_NAME, inputFile.name)
         values.put(MediaStore.Video.Media.MIME_TYPE, mimeType)
         // Add the date meta data to ensure the image is added at the front of the gallery
         values.put(MediaStore.Video.Media.DATE_ADDED, System.currentTimeMillis())
-        values.put(MediaStore.Video.Media.DATE_TAKEN, System.currentTimeMillis())
+        values.put(MediaStore.Video.Media.DATE_MODIFIED, System.currentTimeMillis())
 
-        if (android.os.Build.VERSION.SDK_INT < 29) {
-            values.put(MediaStore.Video.VideoColumns.DATA, videoFilePath)
-            values.put(MediaStore.Images.Media.DATE_TAKEN, System.currentTimeMillis())
-            values.put(MediaStore.Images.Media.RELATIVE_PATH, Environment.DIRECTORY_PICTURES + File.separator + folderName)
+        if (android.os.Build.VERSION.SDK_INT >= 29) {
+            values.put(MediaStore.Video.Media.DATE_TAKEN, System.currentTimeMillis())
+            values.put(MediaStore.Video.Media.RELATIVE_PATH, Environment.DIRECTORY_MOVIES + File.separator + folderName)
         }
 
 

--- a/android/src/main/kotlin/carnegietechnologies/gallery_saver/FileUtils.kt
+++ b/android/src/main/kotlin/carnegietechnologies/gallery_saver/FileUtils.kt
@@ -266,12 +266,13 @@ internal object FileUtils {
         values.put(MediaStore.Video.Media.DATE_TAKEN, System.currentTimeMillis())
 
         if (android.os.Build.VERSION.SDK_INT < 29) {
-            val r = MediaMetadataRetriever()
-            r.setDataSource(inputPath)
-            val durString = r.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)
-            val duration = durString!!.toInt()
-            
-            values.put(MediaStore.Video.Media.DURATION, duration)
+            try {
+                val r = MediaMetadataRetriever()
+                r.setDataSource(inputPath)
+                val durString = r.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)
+                val duration = durString!!.toInt()
+                values.put(MediaStore.Video.Media.DURATION, duration)
+            } catch(e: Exception) {}
         } else {
             values.put(MediaStore.Video.Media.RELATIVE_PATH, Environment.DIRECTORY_MOVIES + File.separator + folderName)
         }


### PR DESCRIPTION
- Fix videos weren't showing up in the gallery on android < 29.
- Fix albumName too (#135)