### PR TITLE
New way to check if it is an image or video with a url with query

### DIFF
--- a/lib/files.dart
+++ b/lib/files.dart
@@ -29,5 +29,10 @@ bool isLocalFilePath(String path) {
 bool isVideo(String path) =>
     videoFormats.contains(extension(path).toLowerCase());
 
-bool isImage(String path) =>
-    imageFormats.contains(extension(path).toLowerCase());
+bool isImage(String path) {
+  bool output = false;
+  imageFormats.forEach((imageFormat) {
+    if (path.toLowerCase().contains(imageFormat)) output = true;
+  });
+  return output;
+}

--- a/lib/files.dart
+++ b/lib/files.dart
@@ -1,4 +1,3 @@
-import 'package:path/path.dart';
 
 const List<String> videoFormats = [
   '.mp4',
@@ -26,8 +25,13 @@ bool isLocalFilePath(String path) {
   return !uri.scheme.contains(http);
 }
 
-bool isVideo(String path) =>
-    videoFormats.contains(extension(path).toLowerCase());
+bool isVideo(String path) {
+  bool output = false;
+  videoFormats.forEach((videoFormat) {
+    if (path.toLowerCase().contains(videoFormat)) output = true;
+  });
+  return output;
+}
 
 bool isImage(String path) {
   bool output = false;


### PR DESCRIPTION
My error was that the image / video could not be saved if one way or another the url did not end with the format, in this case even if the url has a query it works.